### PR TITLE
update 3.62.c

### DIFF
--- a/chapter3/code/3.62.c
+++ b/chapter3/code/3.62.c
@@ -9,8 +9,8 @@ long switch3(long *p1, long *p2, mode_t action) {
   long result = 0;
   switch(action) {
     case MODE_A:
-      *p2 = *p1;
       result = *p2;
+      *p2 = *p1;
       break;
     case MODE_B:
       *p1 = *p1 + *p2;


### PR DESCRIPTION
原先的代码会让 result 和 *p2 都等于 *p1。
实际上，result 应该等于 *p2 的旧值。