### PR TITLE
fix compile error for store-ele.

### DIFF
--- a/chapter3/code/store-ele/store-ele.s
+++ b/chapter3/code/store-ele/store-ele.s
@@ -15,7 +15,8 @@ store_ele:
   addq %rsi, %rdi               # t3 = i*65
   addq %rax, %rdi               # t3 = i*65 + j*13
   addq %rdi, %rdx               # t4 = i*65 + j*13 + k
-  movq A(,%rdx,8), %rax         # t1 = *(A + 8*t4)
+  leaq A(%rip), %rax            # calculate A PIC code
+  movq (%rax, %rdx, 8), %rax    # t1 = *(A + 8*t4)
   movq %rax, (%rcx)             # *dest = t1
   movl $3640, %eax              # return 3640
   ret


### PR DESCRIPTION
fix this make error for store-ele:
"/usr/bin/ld: store-ele.o: relocation R_X86_64_32S against symbol A can not be used when making a PIE object; recompile with -fPIC"