### PR TITLE
docs: fix simple typo, anwser -> answer

### DIFF
--- a/chapter2/2.65.md
+++ b/chapter2/2.65.md
@@ -1,6 +1,6 @@
 2.65
 
-thanks [this anwser on stackoverflow](http://stackoverflow.com/a/9133406)
+thanks [this answer on stackoverflow](http://stackoverflow.com/a/9133406)
 
 ```c
 !INCLUDE "./code/odd-ones.c"

--- a/chapter4/4.53.md
+++ b/chapter4/4.53.md
@@ -130,7 +130,7 @@ they two happens same time, so xxx must be ret
       +-----------+
 
 when they happen same time, data hazard is prior to ret because if ret doesn't
-stall to avoid data hazard, we get wrong anwser with ISA
+stall to avoid data hazard, we get wrong answer with ISA
 
 **composition 3**: jxx error and data hazard
 


### PR DESCRIPTION
There is a small typo in chapter2/2.65.md, chapter4/4.53.md.

Should read `answer` rather than `anwser`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md