### PR TITLE
fix conducted range of A in 3.68

### DIFF
--- a/site/content/chapter3/3.68.md
+++ b/site/content/chapter3/3.68.md
@@ -6,7 +6,7 @@ date = 2021-02-26T09:15:46+08:00
 {{< include file="./chapter3/code/3.68.s" language="gas" >}}
 
     4 < B <= 8
-    5 < A <= 10
+    6 < A <= 10
     44 < A*B <= 46
 
 only


### PR DESCRIPTION
If A equals 6, then it happens to be 8 + 4 + 12 = 24 bytes before "long u", which fits the alignment. Then it would be "addq 24(%rsi), %rax". So A should be greater than 6.