### PR TITLE
Fix tsub-ok.c

### DIFF
--- a/site/content/chapter2/code/tsub-ok.c
+++ b/site/content/chapter2/code/tsub-ok.c
@@ -6,26 +6,16 @@
 #include <limits.h>
 
 /* Determine whether arguments can be substracted without overflow */
-int tsub_ok(int x, int y)
-{
-    int res = 1;
-
-    (y == INT_MIN) && (res = 0);
-    // if (y == INT_MIN) res = 0;
-
+int tsub_ok(int x, int y) {
     int sub = x - y;
-    int pos_over = x > 0 && y < 0 && sub < 0;
+    int pos_over = x >= 0 && y < 0 && sub < 0;
     int neg_over = x < 0 && y > 0 && sub > 0;
-
-    res = res && !(pos_over || neg_over);
-
-    return res;
+    return !(pos_over || neg_over);
 }
 
-int main(int argc, char* argv[]) {
-  assert(!tsub_ok(0x00, INT_MIN));
-  assert(tsub_ok(0x00, 0x00));
-  return 0;
+int main(int argc, char *argv[]) {
+    assert(!tsub_ok(0x00, INT_MIN));
+    assert(tsub_ok(-1, INT_MIN));
+    assert(tsub_ok(0x00, 0x00));
+    return 0;
 }
-
-


### PR DESCRIPTION
Before this fix, `tsub_ok(-1, INT_MIN)` returned `0`, which is not a correct result since the subtraction `(-1) - INT_MIN` does not cause overflow. (The result of the subtraction `(-1) - INT_MIN` is `INT_MAX`.)
Now this fixed version of tsub_ok returns correct results.
